### PR TITLE
including jsonproperty for current state

### DIFF
--- a/PivotalTrackerDotNet/Domain/Story.cs
+++ b/PivotalTrackerDotNet/Domain/Story.cs
@@ -56,6 +56,7 @@ namespace PivotalTrackerDotNet.Domain
         [JsonProperty(PropertyName = "story_type")]
         public StoryType StoryType { get; set; }
 
+        [JsonProperty(PropertyName = "current_state")]
         public StoryStatus CurrentState { get; set; }
         public int? Estimate { get; set; }
         public DateTimeOffset? AcceptedAt { get; set; }


### PR DESCRIPTION
It seems that without this attribute, the current state value is not being deserialized correctly from the response that pivotal gives.